### PR TITLE
ottimizzato il cleanup dei pacchetti e indici apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian
 
-RUN apt-get update && apt-get install -y curl && apt-get clean
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* 
 
 ENV HANDS_ON_SERVER docker.devel.iit.cnr.it
 ENV HANDS_ON_PORT 18273


### PR DESCRIPTION
Ciao,

secondo me così è meglio e si risparmiano ben 8MByte nelle dimensioni dell'immagine! 

Lorenzo
